### PR TITLE
assertTrue -> assertIsInstance

### DIFF
--- a/tests/mechanisms/test_DPMachine.py
+++ b/tests/mechanisms/test_DPMachine.py
@@ -31,4 +31,4 @@ class TestDPMachine(TestCase):
         mech = BaseDPMachine()
         val = mech.randomise(1)
 
-        self.assertTrue(isinstance(val, float))
+        self.assertIsInstance(val, float)

--- a/tests/mechanisms/test_GeometricFolded.py
+++ b/tests/mechanisms/test_GeometricFolded.py
@@ -73,7 +73,7 @@ class TestGeometricFolded(TestCase):
     def test_half_integer_bounds(self):
         self.mech.set_sensitivity(1).set_epsilon(1).set_bounds(0, 1.5)
         val = self.mech.randomise(0)
-        self.assertTrue(isinstance(val, int))
+        self.assertIsInstance(val, int)
 
     def test_non_half_integer_bounds(self):
         self.mech.set_sensitivity(1).set_epsilon(1)

--- a/tests/models/test_logistic_regression_path.py
+++ b/tests/models/test_logistic_regression_path.py
@@ -22,4 +22,4 @@ class TestLogisticRegression(TestCase):
     def test_with_dataset(self):
         output = _logistic_regression_path(self.X, self.y, Cs=[1e5])
 
-        self.assertTrue(isinstance(output, tuple))
+        self.assertIsInstance(output, tuple)


### PR DESCRIPTION
`self.assertIsInstance(..., ...)` will give more detailed error information than `self.assertTrue(isinstance(..., ...))`.