### PR TITLE
change idx in line 174 of randomise() function

### DIFF
--- a/diffprivlib/mechanisms/exponential.py
+++ b/diffprivlib/mechanisms/exponential.py
@@ -171,7 +171,7 @@ class Exponential(DPMechanism):
         if np.any(rand <= self._probabilities):
             idx = np.argmax(rand <= self._probabilities)
         elif np.isclose(rand, self._probabilities[-1]):
-            idx = len(self._probabilities)
+            idx = len(self._probabilities) - 1
         else:
             raise RuntimeError("Can't find a candidate to return. "
                                "Debugging info: Rand: {}, Probabilities: {}".format(rand, self._probabilities))


### PR DESCRIPTION
#49
Line 174 of https://github.com/IBM/differential-privacy-library/blob/eeae0d776eb9915732b4a30bdc02448ac26cb578/diffprivlib/mechanisms/exponential.py#L174 states that `idx` is `k+1` in the worst case. However, it should be equal to `k` for line 134 of https://github.com/IBM/differential-privacy-library/blob/eeae0d776eb9915732b4a30bdc02448ac26cb578/diffprivlib/tools/quantiles.py#L134 to not throw an "_array index out of bounds_" error.