### PR TITLE
[MNT] diffprivlib 0.6.1

### DIFF
--- a/diffprivlib/__init__.py
+++ b/diffprivlib/__init__.py
@@ -29,4 +29,4 @@ from diffprivlib import models
 from diffprivlib import tools
 from diffprivlib.accountant import BudgetAccountant
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/diffprivlib/tools/histograms.py
+++ b/diffprivlib/tools/histograms.py
@@ -244,7 +244,7 @@ def histogramdd(sample, epsilon=1.0, bins=10, range=None, weights=None, density=
                           "specified for each dimension independently of the data (i.e., using domain knowledge).",
                           PrivacyLeakWarning)
 
-    hist, bin_edges = np.histogramdd(sample, bins=bins, range=range, normed=None, weights=weights, density=None)
+    hist, bin_edges = np.histogramdd(sample, bins=bins, range=range, weights=weights, density=None)
 
     dp_mech = GeometricTruncated(epsilon=epsilon, sensitivity=1, lower=0, upper=maxsize, random_state=random_state)
 


### PR DESCRIPTION
This PR prepares a minor bugfix release to maintain compatibility with the upcoming release of numpy 1.24.0.

## Description
* The `normed` keyword in `np.histogramdd` has been deprecated, and has now been removed from diffprivlib.