### PR TITLE
[BUG] Fixes `_Node` class for scikit-learn v1.3

### DIFF
--- a/.github/workflows/libraries.yml
+++ b/.github/workflows/libraries.yml
@@ -28,6 +28,9 @@ jobs:
           - library: numpy
             version: 1.23.5
             python-version: '3.10'
+          - library: numpy
+            version: 1.24.4
+            python-version: '3.11'
 
           - library: scikit-learn
             version: 0.24.2
@@ -38,6 +41,9 @@ jobs:
           - library: scikit-learn
             version: 1.1.3
             python-version: '3.10'
+          - library: scikit-learn
+            version: 1.2.2
+            python-version: '3.10'
 
           - library: scipy
             version: 1.7.3
@@ -45,6 +51,12 @@ jobs:
           - library: scipy
             version: 1.8.1
             python-version: '3.10'
+          - library: scipy
+            version: 1.9.3
+            python-version: '3.11'
+          - library: scipy
+            version: 1.10.1
+            python-version: '3.11'
 
           - library: crlibm
             python-version: '3.10'

--- a/diffprivlib/models/forest.py
+++ b/diffprivlib/models/forest.py
@@ -631,3 +631,7 @@ class _Node:
         yield 0.0  # Impurity
         yield 0  # n_node_samples
         yield 0.0  # weighted_n_node_samples
+
+        # remove branch when scikit-learn v1.3 is min requirement
+        if len(NODE_DTYPE) > 7:
+            yield False


### PR DESCRIPTION
This PR is a bug-fix to maintain compatibility with [Scikit-Learn v1.3](https://scikit-learn.org/stable/whats_new/v1.3.html)

* `NODE_DTYPE` now contains 8 fields ([GH23595](https://github.com/scikit-learn/scikit-learn/pull/23595)), and we must maintain compatibility with older versions of Scikit-Learn too
* Added older versions of Numpy, Scikit-Learn and Scipy to Github workflow