### PR TITLE
[BUG] Fix bounds calculation in nanmean, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Diffprivlib v0.6
 
 [![Python versions](https://img.shields.io/pypi/pyversions/diffprivlib.svg)](https://pypi.org/project/diffprivlib/)
-[![Downloads](https://pepy.tech/badge/diffprivlib)](https://pepy.tech/project/diffprivlib)
+[![Downloads](https://static.pepy.tech/badge/diffprivlib)](https://pepy.tech/project/diffprivlib)
 [![PyPi version](https://img.shields.io/pypi/v/diffprivlib.svg)](https://pypi.org/project/diffprivlib/)
 [![PyPi status](https://img.shields.io/pypi/status/diffprivlib.svg)](https://pypi.org/project/diffprivlib/)
 [![General tests](https://github.com/IBM/differential-privacy-library/actions/workflows/general.yml/badge.svg)](https://github.com/IBM/differential-privacy-library/actions/workflows/general.yml)

--- a/diffprivlib/tools/utils.py
+++ b/diffprivlib/tools/utils.py
@@ -276,7 +276,7 @@ def _mean(array, epsilon=1.0, bounds=None, axis=None, dtype=None, keepdims=False
         warnings.warn("Bounds have not been specified and will be calculated on the data provided. This will "
                       "result in additional privacy leakage. To ensure differential privacy and no additional "
                       "privacy leakage, specify bounds for each dimension.", PrivacyLeakWarning)
-        bounds = (np.min(array), np.max(array))
+        bounds = (np.nanmin(array), np.nanmax(array))
 
     if axis is not None or keepdims:
         return _wrap_axis(_mean, array, epsilon=epsilon, bounds=bounds, axis=axis, dtype=dtype, keepdims=keepdims,
@@ -432,7 +432,7 @@ def _var(array, epsilon=1.0, bounds=None, axis=None, dtype=None, keepdims=False,
         warnings.warn("Bounds have not been specified and will be calculated on the data provided. This will "
                       "result in additional privacy leakage. To ensure differential privacy and no additional "
                       "privacy leakage, specify bounds for each dimension.", PrivacyLeakWarning)
-        bounds = (np.min(array), np.max(array))
+        bounds = (np.nanmin(array), np.nanmax(array))
 
     if axis is not None or keepdims:
         return _wrap_axis(_var, array, epsilon=epsilon, bounds=bounds, axis=axis, dtype=dtype, keepdims=keepdims,
@@ -720,7 +720,7 @@ def _sum(array, epsilon=1.0, bounds=None, axis=None, dtype=None, keepdims=False,
         warnings.warn("Bounds have not been specified and will be calculated on the data provided. This will "
                       "result in additional privacy leakage. To ensure differential privacy and no additional "
                       "privacy leakage, specify bounds for each dimension.", PrivacyLeakWarning)
-        bounds = (np.min(array), np.max(array))
+        bounds = (np.nanmin(array), np.nanmax(array))
 
     if axis is not None or keepdims:
         return _wrap_axis(_sum, array, epsilon=epsilon, bounds=bounds, axis=axis, dtype=dtype, keepdims=keepdims,

--- a/tests/tools/test_nanmean.py
+++ b/tests/tools/test_nanmean.py
@@ -22,18 +22,18 @@ class TestNanMean(TestCase):
         self.assertIsNotNone(nanmean(a, bounds=(0, 1)))
 
     def test_no_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertWarns(PrivacyLeakWarning):
             res = nanmean(a, epsilon=1)
         self.assertIsNotNone(res)
 
     def test_bad_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertRaises(ValueError):
             nanmean(a, epsilon=1, bounds=(0, -1))
 
     def test_missing_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertWarns(PrivacyLeakWarning):
             res = nanmean(a, epsilon=1, bounds=None)
         self.assertIsNotNone(res)
@@ -54,8 +54,8 @@ class TestNanMean(TestCase):
             self.assertAlmostEqual(res[i], res_dp[i], delta=0.01)
 
     def test_array_like(self):
-        self.assertIsNotNone(nanmean([1, 2, 3], bounds=(1, 3)))
-        self.assertIsNotNone(nanmean((1, 2, 3), bounds=(1, 3)))
+        self.assertIsNotNone(nanmean([1, 2, 3, np.nan], bounds=(1, 3)))
+        self.assertIsNotNone(nanmean((1, 2, 3, np.nan), bounds=(1, 3)))
 
     def test_clipped_output(self):
         a = np.random.random((10,))
@@ -68,6 +68,10 @@ class TestNanMean(TestCase):
         a[2, 2] = np.nan
 
         res = nanmean(a, bounds=(0, 1))
+        self.assertFalse(np.isnan(res))
+
+        with self.assertWarns(PrivacyLeakWarning):
+            res = nanmean(a)
         self.assertFalse(np.isnan(res))
 
     def test_accountant(self):

--- a/tests/tools/test_nanstd.py
+++ b/tests/tools/test_nanstd.py
@@ -22,17 +22,17 @@ class TestNanStd(TestCase):
         self.assertIsNotNone(nanstd(a, bounds=(0, 1)))
 
     def test_no_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertWarns(PrivacyLeakWarning):
             nanstd(a, epsilon=1)
 
     def test_bad_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertRaises(ValueError):
             nanstd(a, epsilon=1, bounds=(0, -1))
 
     def test_missing_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertWarns(PrivacyLeakWarning):
             res = nanstd(a, 1, None)
         self.assertIsNotNone(res)
@@ -53,8 +53,8 @@ class TestNanStd(TestCase):
             self.assertAlmostEqual(res[i], res_dp[i], delta=0.01)
 
     def test_array_like(self):
-        self.assertIsNotNone(nanstd([1, 2, 3], bounds=(1, 3)))
-        self.assertIsNotNone(nanstd((1, 2, 3), bounds=(1, 3)))
+        self.assertIsNotNone(nanstd([1, 2, 3, np.nan], bounds=(1, 3)))
+        self.assertIsNotNone(nanstd((1, 2, 3, np.nan), bounds=(1, 3)))
 
     def test_clipped_output(self):
         a = np.random.random((10,))
@@ -68,6 +68,10 @@ class TestNanStd(TestCase):
         a[2, 2] = np.nan
 
         res = nanstd(a, bounds=(0, 1))
+        self.assertFalse(np.isnan(res))
+
+        with self.assertWarns(PrivacyLeakWarning):
+            res = nanstd(a)
         self.assertFalse(np.isnan(res))
 
     def test_accountant(self):

--- a/tests/tools/test_nansum.py
+++ b/tests/tools/test_nansum.py
@@ -22,18 +22,18 @@ class TestNansum(TestCase):
         self.assertIsNotNone(nansum(a, bounds=(1, 3)))
 
     def test_no_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertWarns(PrivacyLeakWarning):
             res = nansum(a, epsilon=1)
         self.assertIsNotNone(res)
 
     def test_mis_ordered_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertRaises(ValueError):
             nansum(a, epsilon=1, bounds=(1, 0))
 
     def test_missing_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertWarns(PrivacyLeakWarning):
             res = nansum(a, epsilon=1, bounds=None)
         self.assertIsNotNone(res)
@@ -53,8 +53,8 @@ class TestNansum(TestCase):
         self.assertAlmostEqual(res, res_dp, delta=0.01 * res)
 
     def test_array_like(self):
-        self.assertIsNotNone(nansum([1, 2, 3], bounds=(1, 3)))
-        self.assertIsNotNone(nansum((1, 2, 3), bounds=(1, 3)))
+        self.assertIsNotNone(nansum([1, 2, 3, np.nan], bounds=(1, 3)))
+        self.assertIsNotNone(nansum((1, 2, 3, np.nan), bounds=(1, 3)))
 
     def test_axis(self):
         a = np.random.random((1000, 5))
@@ -81,6 +81,10 @@ class TestNansum(TestCase):
         a[2, 2] = np.nan
 
         res = nansum(a, bounds=(0, 1))
+        self.assertFalse(np.isnan(res))
+
+        with self.assertWarns(PrivacyLeakWarning):
+            res = nansum(a)
         self.assertFalse(np.isnan(res))
 
         a = np.array([np.nan] * 10)

--- a/tests/tools/test_nanvar.py
+++ b/tests/tools/test_nanvar.py
@@ -22,17 +22,17 @@ class TestNanVar(TestCase):
         self.assertIsNotNone(nanvar(a, bounds=(0, 1)))
 
     def test_no_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertWarns(PrivacyLeakWarning):
             nanvar(a, epsilon=1)
 
     def test_bad_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertRaises(ValueError):
             nanvar(a, epsilon=1, bounds=(0, -1))
 
     def test_missing_bounds(self):
-        a = np.array([1, 2, 3])
+        a = np.array([1, 2, 3, np.nan])
         with self.assertWarns(PrivacyLeakWarning):
             res = nanvar(a, 1, None)
         self.assertIsNotNone(res)
@@ -53,8 +53,8 @@ class TestNanVar(TestCase):
             self.assertAlmostEqual(res[i], res_dp[i], delta=0.01)
 
     def test_array_like(self):
-        self.assertIsNotNone(nanvar([1, 2, 3], bounds=(1, 3)))
-        self.assertIsNotNone(nanvar((1, 2, 3), bounds=(1, 3)))
+        self.assertIsNotNone(nanvar([1, 2, 3, np.nan], bounds=(1, 3)))
+        self.assertIsNotNone(nanvar((1, 2, 3, np.nan), bounds=(1, 3)))
 
     def test_clipped_output(self):
         a = np.random.random((10,))
@@ -68,6 +68,10 @@ class TestNanVar(TestCase):
         a[2, 2] = np.nan
 
         res = nanvar(a, bounds=(0, 1))
+        self.assertFalse(np.isnan(res))
+
+        with self.assertWarns(PrivacyLeakWarning):
+            res = nanvar(a)
         self.assertFalse(np.isnan(res))
 
     def test_accountant(self):

--- a/tests/tools/test_var.py
+++ b/tests/tools/test_var.py
@@ -70,6 +70,10 @@ class TestVar(TestCase):
         res = var(a, bounds=(0, 1))
         self.assertTrue(np.isnan(res))
 
+        with self.assertWarns(PrivacyLeakWarning):
+            res = var(a)
+        self.assertTrue(np.isnan(res))
+
     def test_accountant(self):
         from diffprivlib.accountant import BudgetAccountant
         acc = BudgetAccountant(1.5, 0)


### PR DESCRIPTION
Fixes #87 

## Description
Running nanmean, nanvar, etc on an array with `NaN` without the `bounds` parameter results in an error, because the bounds are retrieved from the data (with a `PrivacyLeakWarning`) using `np.min` and `np.max`. The bounds are therefore given as `(nan, nan)` which results in an error.

This PR fixes this issue by using `np.nanmin` and `np.nanmax` to retrieve the bounds from the data (when not specified by the user). The `nan` values are preserved by `np.clip` (where bounds an enforced) later in the function.

Extra tests have been added to confirm the fix.