### PR TITLE
[BUG] Compute Exponential mechanism probabilities in log-space to avoid underflow

### DIFF
--- a/diffprivlib/mechanisms/exponential.py
+++ b/diffprivlib/mechanisms/exponential.py
@@ -135,10 +135,18 @@ class Exponential(DPMechanism):
 
         if np.isinf(scale):
             probabilities = np.isclose(utility, 0).astype(float)
+            probabilities *= np.array(measure) if measure else 1
         else:
-            probabilities = np.exp(scale * utility)
+            # Compute weights in log-space (logsumexp trick) so that scale * |utility|
+            # exceeding the float64 exp() range does not round all weights to 0 and
+            # produce a NaN probability vector after normalisation.
+            log_weights = scale * utility
+            if measure:
+                with np.errstate(divide="ignore"):
+                    log_weights = log_weights + np.log(np.array(measure))
+            log_weights -= np.max(log_weights)
+            probabilities = np.exp(log_weights)
 
-        probabilities *= np.array(measure) if measure else 1
         probabilities /= probabilities.sum()
 
         return np.cumsum(probabilities)

--- a/tests/tools/test_quantile.py
+++ b/tests/tools/test_quantile.py
@@ -84,6 +84,23 @@ class TestQuantile(TestCase):
         res = quantile(a, 0.5, epsilon=1, random_state=0)
         self.assertTrue(0 <= res <= 2)
 
+    def test_integer_duplicates_at_median(self):
+        # Regression: a duplicate run at the target rank used to crash with
+        # "Can't find a candidate to return". The EM probability vector
+        # collapsed because exp(scale * utility) underflowed to 0 for indices
+        # outside the duplicate run while the in-run measure was 0; after
+        # normalisation the vector was all-NaN. Fixed by computing weights in
+        # log-space in Exponential._find_probabilities.
+        rng = check_random_state(0)
+        a = np.concatenate([
+            np.full(80_000, 65_000, dtype=np.int64),
+            rng.randint(0, 500_000, size=20_000),
+        ])
+        for eps in (0.3, 0.5, 1.0):
+            res = quantile(a, 0.5, epsilon=eps, bounds=(0, 500_000), random_state=rng)
+            self.assertFalse(np.isnan(res))
+            self.assertAlmostEqual(res, 65_000, delta=1_000)
+
     def test_multiple_q(self):
         rng = check_random_state(0)
         a = rng.random(1000)


### PR DESCRIPTION

Fixes #107.

`Exponential.randomise()` raises `RuntimeError: Can't find a candidate to return` once `np.exp(scale * utility)` underflows to 0 on every per-candidate weight. The probability vector is all-zero before normalisation and all-NaN after, and the rejection-sampling loop has nothing to draw. `tools.quantile` triggers this on integer-valued data with a duplicate run at the target rank (linked issue); any other caller of the Exponential mechanism with a wide utility range can hit the same path.

## Why the existing utility shift is not enough

`_find_probabilities` already does `utility = np.array(utility) - max(utility)` before exponentiating, which keeps `max(scale * utility) = 0` and so `exp(scale * u_max) = 1` survives — but only at the index where `utility` is maximal. When that index has `measure_i = 0` (the regime in the linked issue: a duplicate run at the target rank zeros the corresponding interval lengths), `probabilities *= measure` kills the surviving weight, and every other index has already underflowed. The sum is 0 and `randomise` raises on the resulting NaN vector.

## Patch

`diffprivlib/mechanisms/exponential.py`, `Exponential._find_probabilities`. Combine `scale * utility` with `log(measure)` *before* shifting, so the surviving max is taken over the combined log-weight `scale * u_i + log(mu_i)`:

```python
log_weights = scale * utility
if measure:
    with np.errstate(divide="ignore"):
        log_weights = log_weights + np.log(np.array(measure))
log_weights -= np.max(log_weights)
probabilities = np.exp(log_weights)
```

`measure_i = 0` produces `log(0) = -inf`, so a zero-measure candidate receives weight 0 after the softmax, matching the prior behaviour on the non-underflow path. After the shift at least one entry has `log_weights = 0` and contributes `exp(0) = 1` to the sum, so the sum is always positive.

The pre-existing `utility -= max(utility)` line is kept because the `isinf(scale)` branch still relies on it for the `np.isclose(utility, 0)` candidate selection.

## Privacy

For the data-dependent quantile construction, the output is `D_hat[idx] + U * (D_hat[idx+1] - D_hat[idx])` with `U ~ Uniform[0,1]`, and the density at output value y is `exp(scale * u(D, y)) / Z(D)` with rank sensitivity `Δu = 1` (Smith 2011, §3.2). The patch computes the same `mu_i * exp(scale * u_i) / Z` distribution in log-space; the per-output density is unchanged and the ε-DP argument carries over without modification.

## Test

`tests/tools/test_quantile.py::TestQuantile::test_integer_duplicates_at_median`. 100k integer samples, 80% concentrated at value 65000, q = 0.5, eps in {0.3, 0.5, 1.0}. Pre-patch: `RuntimeError` at every epsilon. Post-patch: returns finite values within 1000 of the true median.

- `pytest tests/tools/test_quantile.py` — 23/23 PASS
- `pytest tests/mechanisms/test_Exponential.py` — 20/20 PASS
- `pytest tests/tools/ tests/mechanisms/` — 606/608 PASS (the two failures are pre-existing `test_Snapping.py` int32 issues on Windows, present on unmodified HEAD)

n = 1,000,000 sanity at the regime in the linked issue: 60 trials × 3 eps = 180 calls, 0 crashes. eps = 0.5 alone: 60 unique outputs, exact 65000.0 returned 0 times (no point mass at the duplicate value), output range [65000.01, 65033.73] in the boundary positive interval, as expected for the data-dependent EM.

## Checklist

- [x] Tests added
- [x] Existing Exponential and quantile tests pass
- [x] No new dependencies
