### PR TITLE
Fix diagonal sensitivity calculation in LinearRegression (only used lower bound)

### DIFF
--- a/diffprivlib/models/linear_regression.py
+++ b/diffprivlib/models/linear_regression.py
@@ -141,7 +141,7 @@ def _construct_regression_obj(X, y, bounds_X, bounds_y, epsilon, alpha, random_s
     mono_coef_2 = np.zeros((n_features, n_features))
 
     for i in range(n_features):
-        sensitivity = np.max(np.abs([bounds_X[0][i], bounds_X[0][i]])) ** 2
+        sensitivity = np.max(np.abs([bounds_X[0][i], bounds_X[1][i]])) ** 2
         mech = LaplaceFolded(epsilon=local_epsilon, sensitivity=sensitivity, lower=0, upper=float("inf"),
                              random_state=random_state)
         mono_coef_2[i, i] = mech.randomise(coefs[2][i, i])

--- a/tests/models/test_LinearRegression.py
+++ b/tests/models/test_LinearRegression.py
@@ -1,7 +1,8 @@
 import numpy as np
 from unittest import TestCase
 
-from diffprivlib.models.linear_regression import LinearRegression
+from diffprivlib.mechanisms import LaplaceFolded
+from diffprivlib.models.linear_regression import LinearRegression, _construct_regression_obj
 from diffprivlib.utils import PrivacyLeakWarning, DiffprivlibCompatibilityWarning, BudgetError, check_random_state
 
 
@@ -132,6 +133,39 @@ class TestLinearRegression(TestCase):
         self.assertIsNotNone(clf)
         self.assertIsNotNone(clf._preprocess_data(X, y, fit_intercept=True, bounds_X=(-1, 1), bounds_y=(-1, 1),
                                                   check_input=False, copy=True))
+
+    def test_diagonal_sensitivity_uses_both_bounds(self):
+        # Regression test: the diagonal (X_i * X_i) sensitivity calculation in
+        # _construct_regression_obj used bounds_X[0][i] twice instead of
+        # bounds_X[0][i] and bounds_X[1][i], silently underestimating (and, when
+        # the lower bound is 0, zeroing out) the calibrated noise for that
+        # coefficient.
+        recorded_sensitivities = []
+        orig_init = LaplaceFolded.__init__
+
+        def recording_init(mech_self, *args, **kwargs):
+            recorded_sensitivities.append(kwargs.get("sensitivity"))
+            orig_init(mech_self, *args, **kwargs)
+
+        X = np.array([[10.0], [20.0], [30.0]])
+        y = np.array([1.0, 2.0, 3.0])
+        bounds_X = (np.array([0.0]), np.array([100.0]))
+        bounds_y = (np.array([0.0]), np.array([10.0]))
+
+        LaplaceFolded.__init__ = recording_init
+        try:
+            _construct_regression_obj(X, y, bounds_X, bounds_y, epsilon=1.0, alpha=0.0,
+                                       random_state=check_random_state(0))
+        finally:
+            LaplaceFolded.__init__ = orig_init
+
+        # recorded_sensitivities[0] is the bounds_y-based 0th-degree term (line
+        # 126, unaffected by the bug); recorded_sensitivities[1] is the
+        # bounds_X-based diagonal 2nd-degree term for feature 0 (line 144, the
+        # line under test). With bounds_X = (0, 100), the correct sensitivity is
+        # max(|0|, |100|) ** 2 = 10000; the bug produced 0.0 (only the lower
+        # bound was ever consulted).
+        self.assertEqual(recorded_sensitivities[1], 100.0 ** 2)
 
     def test_multiple_targets(self):
         from sklearn.linear_model import LinearRegression as sk_LinearRegression


### PR DESCRIPTION
Fixes #105.

## The bug

`_construct_regression_obj` (in `diffprivlib/models/linear_regression.py`) computes the sensitivity for each diagonal `X_i * X_i` 2nd-degree monomial coefficient as:

```python
sensitivity = np.max(np.abs([bounds_X[0][i], bounds_X[0][i]])) ** 2
```

`bounds_X[0][i]` (the lower bound) is duplicated instead of pairing it with `bounds_X[1][i]` (the upper bound). This silently **underestimates** the true sensitivity whenever a feature's bounds aren't symmetric around zero, and produces a sensitivity of **exactly 0.0** whenever the lower bound is 0 - regardless of how large the upper bound is.

`LaplaceFolded` is then constructed with that too-small (or zero) sensitivity, so it calibrates essentially no noise for that coefficient. This isn't just numerically wrong output - the differential privacy guarantee for that term is silently weaker than the requested `epsilon`.

Both the off-diagonal case a few lines below (`get_max_sensitivity`) and the analogous `bounds_y`-based 0th-degree term above it (line 126) already correctly use the lower/upper pair; this brings the diagonal case in line with them.

## The fix

```python
sensitivity = np.max(np.abs([bounds_X[0][i], bounds_X[1][i]])) ** 2
```

One-character change (`[0]` -> `[1]` on the second element).

## Verification

Didn't just trust the report - installed the actual released package (0.6.6, matching the version in #105) and called `_construct_regression_obj` directly with `bounds_X=(0, 100)`, the exact scenario from the issue:
- **Unpatched**: sensitivity = `0.0`
- **Patched**: sensitivity = `10000.0` (`max(|0|, |100|) ** 2`, correct)

Added a regression test (`test_diagonal_sensitivity_uses_both_bounds`) that does this directly by recording the `sensitivity` kwarg `LaplaceFolded` is constructed with. Confirmed it fails against the old code and passes against the fix. Also ran the full existing `test_LinearRegression.py` suite (all 13 tests, including the new one) against the fix - no regressions.